### PR TITLE
Notice user when not running as root.

### DIFF
--- a/mitmf.py
+++ b/mitmf.py
@@ -41,7 +41,7 @@ mitmf_version = '0.9.8'
 mitmf_codename = 'The Dark Side'
 
 if os.geteuid() != 0:
-    sys.exit("[-] The derp is strong with this one")
+    sys.exit("[-] The derp is strong with this one\nTIP: you may run MITMf as root.")
 
 parser = argparse.ArgumentParser(description="MITMf v{} - '{}'".format(mitmf_version, mitmf_codename), 
                                  version="{} - '{}'".format(mitmf_version, mitmf_codename), 


### PR DESCRIPTION
The mocking message that was at this place before was... hurting.
Fixed. ( maybe it's a design principe, I don't know )

Exemple output: ```
 __  __   ___   .--.          __  __   ___              
|  |/  `.'   `. |__|         |  |/  `.'   `.      _.._  
|   .-.  .-.   '.--.     .|  |   .-.  .-.   '   .' .._| 
|  |  |  |  |  ||  |   .' |_ |  |  |  |  |  |   | '     
|  |  |  |  |  ||  | .'     ||  |  |  |  |  | __| |__   
|  |  |  |  |  ||  |'--.  .-'|  |  |  |  |  ||__   __|  
|  |  |  |  |  ||  |   |  |  |  |  |  |  |  |   | |     
|__|  |__|  |__||__|   |  |  |__|  |__|  |__|   | |     
                       |  '.'                   | |     
                       |   /                    | |     
                       `'-'                     |_|

[-] The derp is strong with this one
TIP: you may run MITMf as root.
```